### PR TITLE
Fixed broken link to E. M. Reginold's Tidier Tree Drawing paper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # elm-tree-diagram
 This is an Elm package for drawing diagrams of trees. For positioning the
-trees it uses the approach described in [Tidier Drawings of Trees](http://emr.cs.iit.edu/~reingold/tidier-drawings.pdf).
+trees it uses the approach described in [Tidier Drawings of Trees](https://reingold.co/tidier-drawings.pdf).
 
 ## Usage
 Here's the tree data structure we want to draw:


### PR DESCRIPTION
The previous link to the paper is dead. The new link has been proposed in the pull request. Alternatively, there's an [archived link](https://web.archive.org/web/20240602122032/https://reingold.co/tidier-drawings.pdf) on Way Back Machine as well (but this is not included in the changes to the ReadMe).